### PR TITLE
Add map screen with geolocation alerts

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -50,6 +50,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="map"
+        options={{
+          title: 'Map',
+          tabBarIcon: ({ color }) => <TabBarIcon name="map" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, StyleSheet } from 'react-native';
+import MapView, { Marker, Region } from 'react-native-maps';
+import * as Location from 'expo-location';
+import landmarks from '../../assets/data/landmarks.json';
+
+interface Landmark {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  description: string;
+}
+
+export default function MapScreen() {
+  const [region, setRegion] = useState<Region | null>(null);
+  const [notifiedIds, setNotifiedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        Alert.alert('Permission required', 'Allow location access to use the map.');
+        return;
+      }
+
+      const current = await Location.getCurrentPositionAsync({});
+      setRegion({
+        latitude: current.coords.latitude,
+        longitude: current.coords.longitude,
+        latitudeDelta: 0.05,
+        longitudeDelta: 0.05,
+      });
+
+      await Location.watchPositionAsync(
+        { accuracy: Location.Accuracy.High, distanceInterval: 50 },
+        (loc) => {
+          const { latitude, longitude } = loc.coords;
+          setRegion((r) =>
+            r
+              ? { ...r, latitude, longitude }
+              : { latitude, longitude, latitudeDelta: 0.05, longitudeDelta: 0.05 }
+          );
+          checkProximity(latitude, longitude);
+        }
+      );
+    })();
+  }, []);
+
+  const checkProximity = (lat: number, lon: number) => {
+    landmarks.forEach((lm: Landmark) => {
+      if (!notifiedIds.has(lm.id)) {
+        const distance = getDistance(lat, lon, lm.latitude, lm.longitude);
+        if (distance < 200) {
+          setNotifiedIds((prev) => new Set(prev).add(lm.id));
+          Alert.alert('Nearby Landmark', `You\'re near ${lm.name}`);
+        }
+      }
+    });
+  };
+
+  const getDistance = (lat1: number, lon1: number, lat2: number, lon2: number) => {
+    const R = 6371000;
+    const dLat = ((lat2 - lat1) * Math.PI) / 180;
+    const dLon = ((lon2 - lon1) * Math.PI) / 180;
+    const a =
+      0.5 - Math.cos(dLat) / 2 +
+      (Math.cos(lat1 * (Math.PI / 180)) *
+        Math.cos(lat2 * (Math.PI / 180)) *
+        (1 - Math.cos(dLon))) /
+        2;
+    return R * 2 * Math.asin(Math.sqrt(a));
+  };
+
+  if (!region) {
+    return null;
+  }
+
+  return (
+    <MapView style={styles.map} region={region} showsUserLocation>
+      {(landmarks as Landmark[]).map((lm) => (
+        <Marker
+          key={lm.id}
+          coordinate={{ latitude: lm.latitude, longitude: lm.longitude }}
+          title={lm.name}
+          description={lm.description}
+        />
+      ))}
+    </MapView>
+  );
+}
+
+const styles = StyleSheet.create({
+  map: {
+    flex: 1,
+  },
+});
+

--- a/assets/data/landmarks.json
+++ b/assets/data/landmarks.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "name": "Martin Luther King Jr. Memorial",
+    "latitude": 38.8893,
+    "longitude": -77.0502,
+    "description": "Memorial dedicated to civil rights leader Martin Luther King Jr."
+  },
+  {
+    "id": 2,
+    "name": "African American Civil War Memorial",
+    "latitude": 38.9164,
+    "longitude": -77.0259,
+    "description": "Monument honoring Black soldiers who fought in the Civil War."
+  },
+  {
+    "id": 3,
+    "name": "Frederick Douglass National Historic Site",
+    "latitude": 38.8606,
+    "longitude": -76.9855,
+    "description": "Home of famed abolitionist Frederick Douglass."
+  }
+]

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Text
+  style={
+    [
+      {
+        "color": "#000",
+      },
+      [
+        undefined,
+        {
+          "fontFamily": "SpaceMono",
+        },
+      ],
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;


### PR DESCRIPTION
## Summary
- add local landmark data
- create a Map screen that reads landmarks.json
- show markers and alert when nearby
- register Map in tab navigation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a6f9a861c832b8f00a2a0fb88e5df